### PR TITLE
Update hub.py to fix an assumption

### DIFF
--- a/src/rakopy/hub.py
+++ b/src/rakopy/hub.py
@@ -407,15 +407,24 @@ class Hub:
         Converts JSON data to Room.
         """
         channels = []
+        channel1P = True
+        colorType1 = None
+        colorTitle1 = None
+        multiChannelComponent1 = None
         for channel in data["channel"]:
+            if channel1P:
+                channel1P = False
+                colorType1 = channel.get("colorType", None)
+                colorTitle1 = channel.get("colorTitle", None)
+                multiChannelComponent1 = channel.get("multiChannelComponent", None)
             channels.append(
                 Channel(
                     id = channel["channelId"],
                     title = channel["title"],
                     type = channel["type"],
-                    color_type = channel["colorType"],
-                    color_title = channel["colorTitle"],
-                    multi_channel_component = channel["multiChannelComponent"]
+                    color_type = channel.get("colorType", colorType1),
+                    color_title = channel.get("colorTitle", colorTitle1),
+                    multi_channel_component = channel.get("multiChannelComponent", multiChannelComponent1)
                 )
             )
 


### PR DESCRIPTION
Fixes a bug in function _to_room() (line 405)
The prior code assumed that the data for every channel includes the fields colorType, colorTitle and multiChannelComponent. On page 24 of ‘Accessing the Rako Hub from an external application v 0.3.0’, the API specification states in respect of colorType that 'This will only be set for the first channel in a multichannel sequence.' I found the field is not included in subsequent channels and the code failed. Initially I changed the code to use the Python get function with a default value of None. After further thought, I changed it to store and reuse the value provided in the first channel for all subsequent channels.  Initially I made this correction for just colorType but immediately got the same error for colorTitle. So I made the change for all three fields. The code then worked and created the light entities.

ps - thanks for a great integration. I had just set out to program it myself when I found your version - saved me a huge amount of work! I am an experienced programmer but this would have been my first HA integration and my first code in Python - quite a learning curve! Thanks for sharing!