### PR TITLE
Increase stream reader limit to 1 MB

### DIFF
--- a/src/rakopy/hub.py
+++ b/src/rakopy/hub.py
@@ -318,7 +318,8 @@ class Hub:
                 self._writer.transport is None or
                 self._writer.transport.is_closing()
             ):
-                self._reader, self._writer = await asyncio.open_connection(self.host, self.port, limit=1048576)
+                self._reader, self._writer = await asyncio.open_connection(
+                    self.host, self.port, limit=1048576)
 
                 payload = {
                     "version": 2,

--- a/src/rakopy/hub.py
+++ b/src/rakopy/hub.py
@@ -237,7 +237,7 @@ class Hub:
                 writer.transport is None or
                 writer.transport.is_closing()
             ):
-                reader, writer = await asyncio.open_connection(self.host, self.port)
+                reader, writer = await asyncio.open_connection(self.host, self.port, limit=1048576)
 
             payload = {
                 "version": 2,
@@ -318,7 +318,7 @@ class Hub:
                 self._writer.transport is None or
                 self._writer.transport.is_closing()
             ):
-                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port, limit=1048576)
 
                 payload = {
                     "version": 2,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -313,7 +313,7 @@ class TestReconnect:
 
             await hub._reconnect()
 
-            mock_conn.assert_called_once_with("192.168.1.42", DEFAULT_PORT)
+            mock_conn.assert_called_once_with("192.168.1.42", DEFAULT_PORT, limit=1048576)
             # Should have sent SUB message
             writer.write.assert_called_once()
             sent = writer.write.call_args[0][0].decode()


### PR DESCRIPTION
Hub firmware 3.9.0 can return responses larger than asyncio's default 64 KB readline buffer, causing LimitOverrunError on get_levels and leaving Home Assistant entities unavailable.