### PR TITLE
Bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The v0.0.7 publish [failed](https://github.com/princekama/rakopy/actions/runs/33300486829) before uploading anything:

```
Checking dist/rakopy-0.0.7-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Cause

Not a packaging change on our side — the pin aged out. `pypa/gh-action-pypi-publish` was pinned to `27b3170`, a 2023-era commit whose bundled twine predates `Metadata-Version: 2.5`. hatchling has since moved to 1.32.0, which emits 2.5. v0.0.6 built under an older hatchling in June and slipped through.

## Change

Repin to `dc37677` (v1.14.2, released 2026-07-29), keeping the repo's practice of pinning by commit SHA rather than a floating `release/v1`.

## Verified locally

Built the wheel from `main` with the current toolchain:

```
Metadata-Version: 2.5
Name: rakopy
Version: 0.0.7

Checking dist/rakopy-0.0.7-py3-none-any.whl: PASSED
twine version 7.0.0
```

v1.14.2 bundles twine ≥ 7, so the same artifact that failed now passes the check.

## Follow-up

Nothing was uploaded, so `0.0.7` is still free on PyPI. After this merges the `v0.0.7` tag and release need recreating against the new `main` — a workflow re-run would replay the old workflow file from the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RDDrs25mSsY1G8VF7PVTi